### PR TITLE
Allow more than 1 nesting level

### DIFF
--- a/i18n.class.php
+++ b/i18n.class.php
@@ -266,7 +266,7 @@ class i18n {
         $code = '';
         foreach ($config as $key => $value) {
             if (is_array($value)) {
-                $code .= $this->compile($value, $key . $this->sectionSeperator);
+                $code .= $this->compile($value, $prefix . $key . $this->sectionSeperator);
             } else {
                 $code .= 'const ' . $prefix . $key . ' = \'' . str_replace('\'', '\\\'', $value) . "';\n";
             }


### PR DESCRIPTION
The following yml :

``` yaml
test:
  nested:
    string: This is a test
```

would give the following key : `nested_string`, only the last 2 keys would be processed when creating the constant name.
