### PR TITLE
Translations can receive arguments

### DIFF
--- a/i18n.class.php
+++ b/i18n.class.php
@@ -151,7 +151,9 @@ class i18n {
 
             $compiled = "<?php class " . $this->prefix . " {\n";
             $compiled .= $this->compile($config);
-            $compiled .= '}';
+            $compiled .= 'public static function __callStatic($string, $args) {' . "\n";
+            $compiled .= 'vprintf(constant("self::" . $string), $args);' . "\n";
+            $compiled .= "}\n}";
 
             file_put_contents($this->cacheFilePath, $compiled);
             chmod($this->cacheFilePath, 0777);


### PR DESCRIPTION
Translations are able to receive unlimited number of arguments.

Given the translation file:

```
greetings = Hi, %s.
myname = My first name is %s, and my last name is %s.
thisWorksAsWell = Handy I think!
```

and following PHP code:

```
$name = "Stefan";
$last = "Crnjakovic";

echo L::greetings($name);
echo L::myname($name, $lastname);
echo L::thisWorksAsWell;
```

output would look like this:

```
Hi, Stefan.
My first name is Stefan, and my last name is Crnjakovic.
Handy I think!
```
