### PR TITLE
More exceptions are thrown at cache creation for better debugging

### DIFF
--- a/i18n.class.php
+++ b/i18n.class.php
@@ -158,9 +158,15 @@ class i18n {
             $compiled .= 'vprintf(constant("self::" . $string), $args);' . "\n";
             $compiled .= "}\n}";
 
-            file_put_contents($this->cacheFilePath, $compiled);
-            chmod($this->cacheFilePath, 0777);
+            if (!is_writable($this->cachePath)) {
+                throw new Exception('Cache path not writable.');
+            }
 
+            if (file_put_contents($this->cacheFilePath, $compiled)) {
+                chmod($this->cacheFilePath, 0777);
+            } else {
+                throw new RuntimeException('Could not create cache file.');
+            }
         }
 
         require_once $this->cacheFilePath;


### PR DESCRIPTION
When creating the cached class, I added some exception throws that helped me through debugging.

Feel free to refuse it if you don't think it will be really useful.
