### PR TITLE
Composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,20 @@
+{
+    "authors": [
+        {
+            "email": "github@philworld.de",
+            "name": "Philipp Schröer"
+        }
+    ],
+    "autoload": {
+        "files": [ "i18n.class.php" ]
+    },
+    "description": "Simple i18n class for PHP",
+    "license": "CC BY-SA 3.0",
+    "name": "philipp15b/php-i18n",
+    "homepage": "https://github.com/Philipp15b/php-i18n",
+    "support": {
+        "issues": "https://github.com/Philipp15b/php-i18n/issues",
+        "source": "https://github.com/Philipp15b/php-i18n"
+    },
+    "type": "library"
+}


### PR DESCRIPTION
Related to #15

This should do the trick. I could have specified the spyc dependency in composer, but it is already included in the `vendor` directory, no need to duplicate it.

I'm currently using it like this :
``` json
   "require": {
        "philipp15b/php-i18n": "dev-master"
    },
    "repositories": [
      {
        "type": "vcs",
        "url": "https://github.com/bgarret/php-i18n"
      }
    ]
```
Once merged into master, it would be good if you could publish it on packagist (the process is straightforward once the `composer.json` is committed). This would remove the need to declare the repository.

Thoughts?