### PR TITLE
Helper function for dynamic access to constants & vprint -> vsprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Some of its features:
 * Translation strings in `.ini`/`.properties`, `.json` or `.yaml` format
 * Caching
 * Simple API: `L::category_stringname`
-* Built-in support for [vprintf](http://php.net/manual/en/function.vprintf.php) formatting: `L::name($par1)`
+* Built-in support for [vsprintf](http://php.net/manual/en/function.vsprintf.php) formatting: `L::name($par1)`
 * Automatic user language detection
 * Simplicity ;)
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ In this example, we use the translation string seen in step 1.
 
 As you can see, you can also call the constant as a function. It will be formatted with [vsprintf](http://php.net/manual/en/function.vsprintf.php).
 
-A helper function with the same name as the class help access the constants dynamically if ever need.
+Also, like in the two last examples, a helper function with the same name as the class makes it easier to dynamically access the constants if ever needed.
 
 Thats it!
 

--- a/README.md
+++ b/README.md
@@ -119,16 +119,25 @@ In this example, we use the translation string seen in step 1.
 <?php
 	echo L::greeting;
 	// If 'en' is applied: 'Hello World'
-
+	
 	echo L::category_somethingother;
 	// If 'en' is applied: 'Something other...'
-  
+	
 	echo L::last_modified("today");
 	// Could be: 'Last modified: today'
+	
+	echo L($string);
+	// Outputs a dynamically chosen static property
+	
+	echo L($string, $args);
+	// Same as L::last_modified("today");
+	
 ?>
 ```
 
-As you can see, you can also call the constant as a function. It will be formatted with [vprintf](http://php.net/manual/en/function.vprintf.php).
+As you can see, you can also call the constant as a function. It will be formatted with [vsprintf](http://php.net/manual/en/function.vsprintf.php).
+
+A helper function with the same name as the class help access the constants dynamically if ever need.
 
 Thats it!
 

--- a/i18n.class.php
+++ b/i18n.class.php
@@ -159,8 +159,7 @@ class i18n {
             $compiled .= 'public static function __callStatic($string, $args) {' . "\n";
             $compiled .= '    return vsprintf(constant("self::" . $string), $args);' . "\n";
             $compiled .= "}\n}\n";
-            $compiled .="function ".$this->prefix ."(){\n";
-            $compiled .='    $args=func_get_args();$string=array_shift($args);'."\n";
+            $compiled .="function ".$this->prefix .'($string,$args){'."\n";
             $compiled .='    $return=constant("'.$this->prefix.'::".$string);'."\n";
             $compiled .='    return $args ? vsprintf($return,$args) : $return;'."\n}";
 

--- a/i18n.class.php
+++ b/i18n.class.php
@@ -159,7 +159,7 @@ class i18n {
             $compiled .= 'public static function __callStatic($string, $args) {' . "\n";
             $compiled .= '    return vsprintf(constant("self::" . $string), $args);' . "\n";
             $compiled .= "}\n}\n";
-            $compiled .="function ".$this->prefix .'($string,$args){'."\n";
+            $compiled .="function ".$this->prefix .'($string,$args=NULL{'."\n";
             $compiled .='    $return=constant("'.$this->prefix.'::".$string);'."\n";
             $compiled .='    return $args ? vsprintf($return,$args) : $return;'."\n}";
 

--- a/i18n.class.php
+++ b/i18n.class.php
@@ -158,7 +158,11 @@ class i18n {
             $compiled .= $this->compile($config);
             $compiled .= 'public static function __callStatic($string, $args) {' . "\n";
             $compiled .= '    return vsprintf(constant("self::" . $string), $args);' . "\n";
-            $compiled .= "}\n}";
+            $compiled .= "}\n}\n";
+            $compiled .="function ".$this->prefix ."(){\n";
+            $compiled .='    $args=func_get_args();$string=array_shift($args);'."\n";
+            $compiled .='    $return=constant("'.$this->prefix.'::".$string);'."\n";
+            $compiled .='    return $args ? vsprintf($return,$args) : $return;'."\n}";
 
 			if( ! is_dir($this->cachePath))
 				mkdir($this->cachePath,0777,true);

--- a/i18n.class.php
+++ b/i18n.class.php
@@ -154,14 +154,15 @@ class i18n {
                     throw new InvalidArgumentException($this->get_file_extension() . " is not a valid extension!");
             }
 
-            $compiled = "<?php class " . $this->prefix . " {\n";
-            $compiled .= $this->compile($config);
-            $compiled .= 'public static function __callStatic($string, $args) {' . "\n";
-            $compiled .= '    return vsprintf(constant("self::" . $string), $args);' . "\n";
-            $compiled .= "}\n}\n";
-            $compiled .="function ".$this->prefix .'($string,$args=NULL{'."\n";
-            $compiled .='    $return=constant("'.$this->prefix.'::".$string);'."\n";
-            $compiled .='    return $args ? vsprintf($return,$args) : $return;'."\n}";
+            $compiled = "<?php class " . $this->prefix . " {\n"
+            	. $this->compile($config)
+            	. 'public static function __callStatic($string, $args) {' . "\n"
+            	. '    return vsprintf(constant("self::" . $string), $args);'
+            	. "\n}\n}\n"
+            	. "function ".$this->prefix .'($string, $args=NULL) {'."\n"
+            	. '    $return = constant("'.$this->prefix.'::".$string);'."\n"
+            	. '    return $args ? vsprintf($return,$args) : $return;'
+            	. "\n}";
 
 			if( ! is_dir($this->cachePath))
 				mkdir($this->cachePath,0777,true);


### PR DESCRIPTION
Since static classes cannot be invoked but can share namespace with functions, calling a dynamic string name instead of using `constant('L::'.$string)` and rather than a named method like `L::get($string)` can in fact be done with the help of a new function that accesses the class' properties.

How to use: `L($string)`, or `L($string,$args)` for vsprintf formatting.