### PR TITLE
Feature check constant exists while use dynamic access to constants

### DIFF
--- a/i18n.class.php
+++ b/i18n.class.php
@@ -157,9 +157,12 @@ class i18n {
             $compiled = "<?php class " . $this->prefix . " {\n"
                 . $this->compile($config)
                 . 'public static function __callStatic($string, $args) {' . "\n"
-                . '    return vsprintf(constant("self::" . $string), $args);'
+                . '    return defined("self::".$string) ? vsprintf(constant("self::" . $string), $args) : $string;'
                 . "\n}\n}\n"
                 . "function ".$this->prefix .'($string, $args=NULL) {'."\n"
+                . '    if (!defined("'.$this->prefix.'::".$string)) {'."\n"
+                . '        return $string;'."\n"
+                . '    }'."\n"
                 . '    $return = constant("'.$this->prefix.'::".$string);'."\n"
                 . '    return $args ? vsprintf($return,$args) : $return;'
                 . "\n}";

--- a/i18n.class.php
+++ b/i18n.class.php
@@ -155,18 +155,19 @@ class i18n {
             }
 
             $compiled = "<?php class " . $this->prefix . " {\n"
-            	. $this->compile($config)
-            	. 'public static function __callStatic($string, $args) {' . "\n"
-            	. '    return vsprintf(constant("self::" . $string), $args);'
-            	. "\n}\n}\n"
-            	. "function ".$this->prefix .'($string, $args=NULL) {'."\n"
-            	. '    $return = constant("'.$this->prefix.'::".$string);'."\n"
-            	. '    return $args ? vsprintf($return,$args) : $return;'
-            	. "\n}";
+                . $this->compile($config)
+                . 'public static function __callStatic($string, $args) {' . "\n"
+                . '    return vsprintf(constant("self::" . $string), $args);'
+                . "\n}\n}\n"
+                . "function ".$this->prefix .'($string, $args=NULL) {'."\n"
+                . '    $return = constant("'.$this->prefix.'::".$string);'."\n"
+                . '    return $args ? vsprintf($return,$args) : $return;'
+                . "\n}";
 
-			if( ! is_dir($this->cachePath))
-				mkdir($this->cachePath,0777,true);
-			
+            if (!is_dir($this->cachePath)) {
+                mkdir($this->cachePath,0777,true);
+            }
+
             if (file_put_contents($this->cacheFilePath, $compiled) === FALSE) {
                 throw new Exception("Could not write cache file to path '" . $this->cacheFilePath . "'. Is it writable?");
             }


### PR DESCRIPTION
There are some code cleanup for #26. Also I added some checks if passed constant `$string` exists.
If constant not exists just return only $string value as is.
For example:
INI file:

``` ini
HELLO = "Hello"
```

PHP code:

``` php
echo L('HELLO');
// output "Hello" , but

echo L('GOOD_MORNING');  // or  echo L('GOOD_MORNING', array('Garry'));
// output "GOOD_MORNING" without fatal error in log (or try-except needed)
```
