### PR TITLE
fix possible syntax error

### DIFF
--- a/i18n.class.php
+++ b/i18n.class.php
@@ -315,7 +315,12 @@ class i18n {
             if (is_array($value)) {
                 $code .= $this->compile($value, $prefix . $key . $this->sectionSeperator);
             } else {
-                $code .= 'const ' . $prefix . $key . ' = \'' . str_replace('\'', '\\\'', $value) . "';\n";
+                $linePrefix = "";
+                $varName = $prefix . $key;
+                if(!preg_match('@^([a-z_][a-z0-9_]*)$@is', $varName)){
+                    $linePrefix = "//";
+                }
+                $code .= $linePrefix . 'const ' . $varName . ' = \'' . str_replace('\'', '\\\'', $value) . "';\n";
             }
         }
         return $code;


### PR DESCRIPTION
if there is some error in config file accidentally , it may cause php syntax error.
like this:

lang_en.ini 
========= START ======
greeting = "Hello World!"
test-error = "Wrong Line!"
[category]
somethingother = "Something other..."
========= END ======

Error raise below:
Parse error: syntax error, unexpected '-', expecting '=' in xxxxx_L_en.cache.php

The reason is variables name contains illegal character, 
fix method is comment error line in php cache file by //.


