### PR TITLE
fix HTTP Accept-Language parsing; add region variant option; discard empty lang code string at regex level

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The possible settings are:
 <?php
 	$i18n->setCachePath('./tmp/cache');
 	$i18n->setFilePath('./langfiles/lang/lang_{LANGUAGE}.ini'); // language file path
-	$i18n->setLangVariant('false'); // trim region variant in language codes (e.g. en-us -> en)
+	$i18n->setLangVariant(false); // trim region variant in language codes (e.g. en-us -> en)
 	$i18n->setFallbackLang('en');
 	$i18n->setPrefix('I');
 	$i18n->setForcedLang('en'); // force english, even if another user language is available

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The possible settings are:
 <?php
 	$i18n->setCachePath('./tmp/cache');
 	$i18n->setFilePath('./langfiles/lang/lang_{LANGUAGE}.ini'); // language file path
-	$i18n->setLangVariant(false); // trim region variant in language codes (e.g. en-us -> en)
+	$i18n->setLangVariantToggle(false); // trim region variant in language codes (e.g. en-us -> en)
 	$i18n->setFallbackLang('en');
 	$i18n->setPrefix('I');
 	$i18n->setForcedLang('en'); // force english, even if another user language is available

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The possible settings are:
 
 * Language file path (default: `./lang/lang_{LANGUAGE}.ini`)
 * Cache file path (default: `./langcache/`)
+* Preserve language region variants: if set to true, region variants in language code strings such as en-us and en-gb will be preserved, otherwise will be trimmed to en (default: `false`)
 * The fallback language, if no one of the user languages is available (default: `en`)
 * A 'prefix', the compiled class name (default `L`)
 * A forced language, if you want to force a language (default: none)
@@ -79,6 +80,7 @@ The possible settings are:
 <?php
 	$i18n->setCachePath('./tmp/cache');
 	$i18n->setFilePath('./langfiles/lang/lang_{LANGUAGE}.ini'); // language file path
+	$i18n->setLangVariant('false'); // trim region variant in language codes (e.g. en-us -> en)
 	$i18n->setFallbackLang('en');
 	$i18n->setPrefix('I');
 	$i18n->setForcedLang('en'); // force english, even if another user language is available

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The possible settings are:
 <?php
 	$i18n->setCachePath('./tmp/cache');
 	$i18n->setFilePath('./langfiles/lang/lang_{LANGUAGE}.ini'); // language file path
-	$i18n->setLangVariantToggle(false); // trim region variant in language codes (e.g. en-us -> en)
+	$i18n->setLangVariantEnabled(false); // trim region variant in language codes (e.g. en-us -> en)
 	$i18n->setFallbackLang('en');
 	$i18n->setPrefix('I');
 	$i18n->setForcedLang('en'); // force english, even if another user language is available

--- a/i18n.class.php
+++ b/i18n.class.php
@@ -26,6 +26,15 @@ class i18n {
     protected $cachePath = './langcache/';
 
     /**
+     * Enable region variants
+     * Allow region variants such as "en-us", "en-gb" etc. If set to false, "en" will be provided.
+     * Defaults to false for backward compatibility.
+     *
+     * @var bool
+     */
+    protected $variantLang = false;
+
+    /**
      * Fallback language
      * This is the language which is used when there is no language file for all other user languages. It has the lowest priority.
      * Remember to create a language file for the fallback!!
@@ -189,6 +198,10 @@ class i18n {
         return $this->cachePath;
     }
 
+    public function getLangVariant($variantLang) {
+        return $this->$variantLang;
+    }
+
     public function getFallbackLang() {
         return $this->fallbackLang;
     }
@@ -201,6 +214,11 @@ class i18n {
     public function setCachePath($cachePath) {
         $this->fail_after_init();
         $this->cachePath = $cachePath;
+    }
+
+    public function setLangVariant($variantLang) {
+        $this->fail_after_init();
+        $this->variantLang = $variantLang;
     }
 
     public function setFallbackLang($fallbackLang) {
@@ -270,7 +288,13 @@ class i18n {
         // 4th highest priority: HTTP_ACCEPT_LANGUAGE
         if (isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
             foreach (explode(',', $_SERVER['HTTP_ACCEPT_LANGUAGE']) as $part) {
-                $userLangs[] = strtolower(substr($part, 0, 2));
+                $userLang = strtolower(explode(';q=', $part)[0]);
+
+                // Trim language variant section if not configured to allow
+                if (!$this->variantLang)
+                    $userLang = explode('-', $userLang)[0];
+                
+                $userLangs[] = $userLang;
             }
         }
 

--- a/i18n.class.php
+++ b/i18n.class.php
@@ -32,7 +32,7 @@ class i18n {
      *
      * @var bool
      */
-    protected $variantLangToggle = false;
+    protected $langVariantToggle = false;
 
     /**
      * Fallback language
@@ -199,7 +199,7 @@ class i18n {
     }
 
     public function getLangVariantToggle() {
-        return $this->variantLangToggle;
+        return $this->langVariantToggle;
     }
 
     public function getFallbackLang() {
@@ -216,9 +216,9 @@ class i18n {
         $this->cachePath = $cachePath;
     }
 
-    public function setLangVariantToggle($variantLangToggle) {
+    public function setLangVariantToggle($langVariantToggle) {
         $this->fail_after_init();
-        $this->variantLangToggle = $variantLangToggle;
+        $this->langVariantToggle = $langVariantToggle;
     }
 
     public function setFallbackLang($fallbackLang) {
@@ -291,7 +291,7 @@ class i18n {
                 $userLang = strtolower(explode(';q=', $part)[0]);
 
                 // Trim language variant section if not configured to allow
-                if (!$this->variantLangToggle)
+                if (!$this->langVariantToggle)
                     $userLang = explode('-', $userLang)[0];
                 
                 $userLangs[] = $userLang;

--- a/i18n.class.php
+++ b/i18n.class.php
@@ -313,7 +313,7 @@ class i18n {
         $userLangs2 = array();
         foreach ($userLangs as $key => $value) {
             // only allow a-z, A-Z and 0-9 and _ and -
-            if (preg_match('/^[a-zA-Z0-9_-]*$/', $value) === 1)
+            if (preg_match('/^[a-zA-Z0-9_-]+$/', $value) === 1)
                 $userLangs2[$key] = $value;
         }
 

--- a/i18n.class.php
+++ b/i18n.class.php
@@ -32,7 +32,7 @@ class i18n {
      *
      * @var bool
      */
-    protected $langVariantToggle = false;
+    protected $isLangVariantEnabled = false;
 
     /**
      * Fallback language
@@ -198,8 +198,8 @@ class i18n {
         return $this->cachePath;
     }
 
-    public function getLangVariantToggle() {
-        return $this->langVariantToggle;
+    public function getLangVariantEnabled() {
+        return $this->isLangVariantEnabled;
     }
 
     public function getFallbackLang() {
@@ -216,9 +216,9 @@ class i18n {
         $this->cachePath = $cachePath;
     }
 
-    public function setLangVariantToggle($langVariantToggle) {
+    public function setLangVariantEnabled($isLangVariantEnabled) {
         $this->fail_after_init();
-        $this->langVariantToggle = $langVariantToggle;
+        $this->isLangVariantEnabled = $isLangVariantEnabled;
     }
 
     public function setFallbackLang($fallbackLang) {
@@ -291,7 +291,7 @@ class i18n {
                 $userLang = strtolower(explode(';q=', $part)[0]);
 
                 // Trim language variant section if not configured to allow
-                if (!$this->langVariantToggle)
+                if (!$this->isLangVariantEnabled)
                     $userLang = explode('-', $userLang)[0];
                 
                 $userLangs[] = $userLang;

--- a/i18n.class.php
+++ b/i18n.class.php
@@ -32,7 +32,7 @@ class i18n {
      *
      * @var bool
      */
-    protected $variantLang = false;
+    protected $variantLangToggle = false;
 
     /**
      * Fallback language
@@ -198,8 +198,8 @@ class i18n {
         return $this->cachePath;
     }
 
-    public function getLangVariant($variantLang) {
-        return $this->$variantLang;
+    public function getLangVariantToggle() {
+        return $this->variantLangToggle;
     }
 
     public function getFallbackLang() {
@@ -216,9 +216,9 @@ class i18n {
         $this->cachePath = $cachePath;
     }
 
-    public function setLangVariant($variantLang) {
+    public function setLangVariantToggle($variantLangToggle) {
         $this->fail_after_init();
-        $this->variantLang = $variantLang;
+        $this->variantLangToggle = $variantLangToggle;
     }
 
     public function setFallbackLang($fallbackLang) {
@@ -291,7 +291,7 @@ class i18n {
                 $userLang = strtolower(explode(';q=', $part)[0]);
 
                 // Trim language variant section if not configured to allow
-                if (!$this->variantLang)
+                if (!$this->variantLangToggle)
                     $userLang = explode('-', $userLang)[0];
                 
                 $userLangs[] = $userLang;


### PR DESCRIPTION
## HTTP Accept-Language Parsing
Since some language codes are 3 characters length, such as
* Asturian (ast)
* Songhay (son)

, also certain language contain variants, such as
* United States English (en-US) and United Kingdom English (en-GB)
* Simplified Chinese (zh-HANS) and Traditional Chinese (zh-HANT)

, the code needs to be revised to adopt them.

## Region Variant Option
This revision is related to the previous one. An `variantLang` option with default value `false` is created for backward compatibility, so the user may choose whether to preserve the variant part or trim them. For example:

* If set to true: en-us -> en-us
* Otherwise: en-us -> en

## Empty Language Code Strings
This is a minor improvement that potentially can reduce disk reads. The original regex accepted empty string, and later will likely be discarded due to no file existing in the file system. Perhaps discarding them at the regex level would be better.

Thank you