### PR TITLE
Allow the use of '.' as section separator

### DIFF
--- a/i18n.class.php
+++ b/i18n.class.php
@@ -169,6 +169,7 @@ class i18n {
             	. '    return vsprintf(constant("self::" . $string), $args);'
             	. "\n}\n}\n"
             	. "function ".$this->prefix .'($string, $args=NULL) {'."\n"
+                . '    $string = str_replace(\'.\', \'_\', $string);' . "\n"
             	. '    $return = constant("'.$this->prefix.'::".$string);'."\n"
             	. '    return $args ? vsprintf($return,$args) : $return;'
             	. "\n}";


### PR DESCRIPTION
Allow the use of a '.' as a section separator when using the helper function by converting the '.' to a '_' in that function.

The drawback is that though `echo L("category.somethingother");` will now work, the constant notation `echo L::category.somethingother;` still will not. This limitation might be the reason for you not to accept this PR which is completely understandable.